### PR TITLE
Remove redundant atom_t typedef, bump to 2.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 # The directory label is used for CDash to treat ATL as a subproject of GTKorvo
 set(CMAKE_DIRECTORY_LABELS ATL)
 
-project(ATL VERSION 2.3.0 LANGUAGES C)
+project(ATL VERSION 2.3.1 LANGUAGES C)
 
 # Some boilerplate to setup nice output directories
 include(GNUInstallDirs)

--- a/http_atom_client.c
+++ b/http_atom_client.c
@@ -48,7 +48,6 @@
 #endif
 
 #include "atl.h"
-typedef int atom_t;
 #include "atom_internal.h"
 
 /* Parsed URL components */


### PR DESCRIPTION
Remove duplicate `typedef int atom_t` in `http_atom_client.c` — already defined in `atl.h`. Fixes `-Wtypedef-redefinition` warning on clang.